### PR TITLE
strip protocol from the video URLs

### DIFF
--- a/js/gfycat_test_.js
+++ b/js/gfycat_test_.js
@@ -152,6 +152,9 @@ var gfyObject = function (gfyElem) {
     function createVidTag() {
         vid = document.createElement('video');
         vid.className = 'gfyVid';
+        var protomatch = /^(https?):/;
+        gfyWebmUrl = gfyWebmUrl.replace(protomatch, '');
+        gfyMp4Url = gfyMp4Url.replace(protomatch, '');
         if (optAutoplay)
             vid.autoplay = true;
         vid.loop = true;


### PR DESCRIPTION
Let the host websites add the required protocol
Video URL

before - `http://fat.gfycat.com/SourBitesizedKitfox.webm`
after - '//fat.gfycat.com/SourBitesizedKitfox.webm'
